### PR TITLE
IOT_DS-8566: fix CLA trigger condition and enable CLA workflow triggers

### DIFF
--- a/.github/workflows/01-CLA-Assistant.yml
+++ b/.github/workflows/01-CLA-Assistant.yml
@@ -28,7 +28,12 @@ jobs:
           repositories: contributor-license-agreements
 
       - name: "CLA Assistant"
-        if: ${{ contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA') }} || github.event_name == 'pull_request_target'
+        if: >
+          github.event_name == 'pull_request_target' ||
+          (github.event_name == 'issue_comment' &&
+           github.event.issue.pull_request &&
+           (github.event.comment.body == 'recheck' ||
+            contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
         uses: SiliconLabsSoftware/action-cla-assistant@silabs_flavour_v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the CLA Assistant workflow trigger condition and enables trigger events for CLA processing.\n\nChanges:\n- Replace the CLA step condition with a guarded expression that handles pull_request_target and qualifying issue_comment events\n- Enable issue_comment and pull_request_target triggers when they were commented out\n\nTicket: IOT_DS-8566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts when the CLA action runs; low blast radius but could affect whether CLA checks trigger as expected.
> 
> **Overview**
> Fixes the `01-CLA-Assistant` GitHub Actions workflow so the CLA check only runs on `pull_request_target` events or on PR `issue_comment` events that either contain the standard CLA sign-off text or are exactly `recheck`.
> 
> This tightens the step-level `if:` guard to avoid triggering CLA processing on non-PR comments while still supporting manual rechecks, and normalizes the YAML formatting (including adding the missing trailing newline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48a5db5e87f7816e4371683ca1982401f4c349c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->