### PR TITLE
IOT_DS-8566: fix CLA trigger conditions

### DIFF
--- a/.github/workflows/01-CLA-Assistant.yml
+++ b/.github/workflows/01-CLA-Assistant.yml
@@ -28,12 +28,7 @@ jobs:
           repositories: contributor-license-agreements
 
       - name: "CLA Assistant"
-        if: >
-          github.event_name == 'pull_request_target' ||
-          (github.event_name == 'issue_comment' &&
-           github.event.issue.pull_request &&
-           (github.event.comment.body == 'recheck' ||
-            contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
+        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))) }}
         uses: SiliconLabsSoftware/action-cla-assistant@silabs_flavour_v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/01-CLA-Assistant.yml
+++ b/.github/workflows/01-CLA-Assistant.yml
@@ -16,6 +16,13 @@ permissions:
 
 jobs:
   CLAAssistant:
+    # Gate the entire job to avoid minting an app token for unrelated comments.
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (github.event.comment.body == 'recheck' ||
+        contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')))
     runs-on: ubuntu-24.04
     steps:
       - name: Create CLA Assistant Lite bot token
@@ -28,7 +35,6 @@ jobs:
           repositories: contributor-license-agreements
 
       - name: "CLA Assistant"
-        if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'issue_comment' && github.event.issue.pull_request && (github.event.comment.body == 'recheck' || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA'))) }}
         uses: SiliconLabsSoftware/action-cla-assistant@silabs_flavour_v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Wrap the full CLA Assistant `if` condition in one GitHub Actions expression block without changing trigger logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that reuses the same condition, with limited blast radius to CLA checks (risk is mainly accidental under/over-triggering if the expression differs).
> 
> **Overview**
> Moves the CLA workflow trigger `if` condition from the `CLA Assistant` step to the entire `CLAAssistant` job, so the GitHub App token is only minted when the event is a PR target event or a qualifying PR comment (`recheck`/CLA-signing text).
> 
> No trigger logic changes are intended; it just gates the job earlier to avoid running token-creation for unrelated `issue_comment` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e89a0dffbd9a27f3fed3f6a66e8f7c9b902e5aa7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->