### PR TITLE
exclude the code-convention workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
-exclude: '.*\/build\/.*|.*\/gecko_sdk.*/.*|.*\/autogen\/.*|.*simplicity.*/.*|.*\/config\/.*|.*\.slcp|.*\.slps|.*\.mak'
+# 00-Check-Code-Convention.yml is excluded by default.
+# If you want to use a different filename, exclude that filename explicitly in the action inputs.
+exclude: '.*\/build\/.*|.*\/gecko_sdk.*/.*|.*\/autogen\/.*|.*simplicity.*/.*|.*\/config\/.*|^\.github\/workflows\/00-Check-Code-Convention\.yml$|.*\.slcp|.*\.slps|.*\.mak'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ Default rules embedded at build time:
 
 ### Inputs
 
-| Input                    | Description                      | Format                 | Example                        |
-| ------------------------ | -------------------------------- | ---------------------- | ------------------------------ |
-| `exclude-regex`          | Paths to exclude from all checks | Regex (pipe-separated) | `.*\/generated\/.*\|.*\.pb\.c` |
-| `codespell-ignore-words` | Words codespell should ignore    | Comma-separated        | `hsi,aci,pullrequest`          |
-| `codespell-skip-paths`   | Files codespell should skip      | Comma-separated globs (fnmatch-style), avoid `**` | `docs/*,third_party/*` |
+| Input                    | Description                      | Format                                            | Example                        |
+| ------------------------ | -------------------------------- | ------------------------------------------------- | ------------------------------ |
+| `exclude-regex`          | Paths to exclude from all checks | Regex (pipe-separated)                            | `.*\/generated\/.*\|.*\.pb\.c` |
+| `codespell-ignore-words` | Words codespell should ignore    | Comma-separated                                   | `hsi,aci,pullrequest`          |
+| `codespell-skip-paths`   | Files codespell should skip      | Comma-separated globs (fnmatch-style), avoid `**` | `docs/*,third_party/*`         |
+
+#### Note:
+The 00-Check-Code-Convention.yml workflow is excluded by default. It shall contain the additional ignored words.
+Which would trigger the action to fail on that workflow file. If you want to use a different workflow filename,  
+you must exclude that filename explicitly.
 
 Custom inputs are applied at runtime inside the container by `handle_custom_inputs.py`.
 


### PR DESCRIPTION
when Ignore words are added to the list, code convention will fail on this file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config/doc update: only adjusts pre-commit exclusion patterns and documents the default workflow exclusion; no runtime logic changes.
> 
> **Overview**
> Updates the default pre-commit `exclude` regex to **skip `.github/workflows/00-Check-Code-Convention.yml` by default**, preventing the action from failing when ignore-words are added to that workflow file.
> 
> Refreshes `README.md` inputs formatting and adds a note explaining the default exclusion and that alternate workflow filenames must be explicitly excluded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e587b62faaf2834747ff610f5f4b1651081aa474. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->